### PR TITLE
feat: Issue #14 — 進捗管理・ダッシュボード

### DIFF
--- a/backend/app/controllers/api/v1/user/progress_controller.rb
+++ b/backend/app/controllers/api/v1/user/progress_controller.rb
@@ -1,0 +1,79 @@
+module Api
+  module V1
+    module User
+      class ProgressController < ApplicationController
+        include Authenticatable
+
+        # GET /api/v1/user/progress
+        # 全コースの進捗サマリー
+        def index
+          courses = ::Course.ordered
+
+          summary = courses.map do |course|
+            lessons       = course.lessons.ordered
+            lesson_ids    = lessons.pluck(:id)
+            quiz_ids      = ::Quiz.where(lesson_id: lesson_ids).pluck(:id)
+            total_lessons = lesson_ids.count
+            total_quizzes = quiz_ids.count
+
+            completed_lessons = current_user.user_progresses
+              .where(lesson_id: lesson_ids, quiz_id: nil, status: "completed")
+              .count
+            completed_quizzes = current_user.user_progresses
+              .where(quiz_id: quiz_ids, status: "completed")
+              .count
+
+            total = total_lessons + total_quizzes
+            completed = completed_lessons + completed_quizzes
+            progress_pct = total > 0 ? (completed * 100 / total) : 0
+
+            {
+              course_id: course.id,
+              title: course.title,
+              category: course.category,
+              difficulty: course.difficulty,
+              total_lessons:,
+              total_quizzes:,
+              completed_lessons:,
+              completed_quizzes:,
+              progress_pct:
+            }
+          end
+
+          render json: { progress: summary }
+        end
+
+        # GET /api/v1/user/progress/courses/:course_id
+        # コース別詳細進捗
+        def course
+          course   = ::Course.find(params[:course_id])
+          lessons  = course.lessons.ordered
+
+          lesson_progress = lessons.map do |lesson|
+            lesson_done = current_user.user_progresses
+              .exists?(lesson:, quiz_id: nil, status: "completed")
+
+            quiz_results = lesson.quizzes.ordered.map do |quiz|
+              prog = current_user.user_progresses.find_by(quiz:)
+              {
+                quiz_id: quiz.id,
+                status: prog&.status || "not_started",
+                score: prog&.score
+              }
+            end
+
+            {
+              lesson_id: lesson.id,
+              title: lesson.title,
+              position: lesson.position,
+              completed: lesson_done,
+              quizzes: quiz_results
+            }
+          end
+
+          render json: { course_id: course.id, title: course.title, lessons: lesson_progress }
+        end
+      end
+    end
+  end
+end

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+import { apiClient } from "@/lib/api";
+
+type CourseProgress = {
+  course_id: number;
+  title: string;
+  category: string;
+  difficulty: string;
+  total_lessons: number;
+  total_quizzes: number;
+  completed_lessons: number;
+  completed_quizzes: number;
+  progress_pct: number;
+};
+
+const categoryLabel: Record<string, string> = {
+  typescript: "TypeScript",
+  react: "React",
+  nextjs: "Next.js",
+  rails: "Rails",
+};
+
+const difficultyColor: Record<string, string> = {
+  beginner: "bg-green-100 text-green-700",
+  intermediate: "bg-yellow-100 text-yellow-700",
+  advanced: "bg-red-100 text-red-700",
+};
+
+export default function DashboardPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [progress, setProgress] = useState<CourseProgress[]>([]);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (!user) return;
+    apiClient
+      .get<{ progress: CourseProgress[] }>("/user/progress")
+      .then((res) => setProgress(res.data.progress))
+      .finally(() => setFetching(false));
+  }, [user]);
+
+  if (loading || fetching) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center text-gray-500">
+        読み込み中...
+      </div>
+    );
+  }
+
+  const totalPct =
+    progress.length > 0
+      ? Math.round(
+          progress.reduce((sum, p) => sum + p.progress_pct, 0) / progress.length
+        )
+      : 0;
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-12">
+      <h1 className="mb-2 text-3xl font-bold text-gray-900">ダッシュボード</h1>
+      <p className="mb-8 text-gray-600">こんにちは、{user?.name} さん</p>
+
+      {/* 全体進捗 */}
+      <div className="mb-8 rounded-xl border bg-white p-6 shadow-sm">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="font-semibold text-gray-800">全体の進捗</span>
+          <span className="text-2xl font-bold text-indigo-600">{totalPct}%</span>
+        </div>
+        <div className="h-3 w-full overflow-hidden rounded-full bg-gray-200">
+          <div
+            className="h-full rounded-full bg-indigo-500 transition-all duration-500"
+            style={{ width: `${totalPct}%` }}
+          />
+        </div>
+      </div>
+
+      {/* コース別進捗 */}
+      <h2 className="mb-4 text-xl font-semibold text-gray-800">コース別進捗</h2>
+      <div className="space-y-4">
+        {progress.map((p) => (
+          <div key={p.course_id} className="rounded-xl border bg-white p-5 shadow-sm">
+            <div className="mb-3 flex items-start justify-between gap-4">
+              <div>
+                <div className="mb-1 flex items-center gap-2">
+                  <span className="rounded-full bg-indigo-100 px-2.5 py-0.5 text-xs font-medium text-indigo-700">
+                    {categoryLabel[p.category] ?? p.category}
+                  </span>
+                  <span
+                    className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${difficultyColor[p.difficulty] ?? ""}`}
+                  >
+                    {p.difficulty}
+                  </span>
+                </div>
+                <Link
+                  href={`/courses/${p.course_id}`}
+                  className="font-semibold text-gray-900 hover:text-indigo-600"
+                >
+                  {p.title}
+                </Link>
+              </div>
+              <span className="shrink-0 text-xl font-bold text-indigo-600">
+                {p.progress_pct}%
+              </span>
+            </div>
+
+            <div className="mb-3 h-2 w-full overflow-hidden rounded-full bg-gray-200">
+              <div
+                className="h-full rounded-full bg-indigo-400 transition-all duration-500"
+                style={{ width: `${p.progress_pct}%` }}
+              />
+            </div>
+
+            <div className="flex gap-6 text-sm text-gray-600">
+              <span>
+                レッスン:{" "}
+                <span className="font-medium text-gray-900">
+                  {p.completed_lessons}/{p.total_lessons}
+                </span>
+              </span>
+              <span>
+                クイズ:{" "}
+                <span className="font-medium text-gray-900">
+                  {p.completed_quizzes}/{p.total_quizzes}
+                </span>
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 text-center">
+        <Link
+          href="/courses"
+          className="inline-block rounded-lg bg-indigo-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          学習を続ける
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `GET /api/v1/user/progress`: 全コース進捗サマリー (progress_pct, completed/total)
- `GET /api/v1/user/progress/courses/:id`: コース別詳細進捗
- `/dashboard`: 全体進捗バー + コース別カード + 未ログイン時リダイレクト

Closes #14

## Test plan

- [ ] ログイン後 /dashboard にアクセス → 全体進捗・コース別進捗表示
- [ ] レッスン完了・クイズ回答後にリロードで進捗更新確認
- [ ] 未ログイン状態で /dashboard → /login へリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)