### PR TITLE
feat: Issue #16/#17/#18 — レッスンロック・ダッシュボード改善・Monaco Editor

### DIFF
--- a/backend/app/controllers/api/v1/courses_controller.rb
+++ b/backend/app/controllers/api/v1/courses_controller.rb
@@ -12,14 +12,39 @@ module Api
 
       # GET /api/v1/courses/:id
       def show
-        course = ::Course.find(params[:id])
-        lessons = course.lessons.ordered.map do |l|
-          { id: l.id, title: l.title, position: l.position }
+        course  = ::Course.find(params[:id])
+        lessons = course.lessons.ordered.to_a
+
+        # 認証ユーザーの完了レッスン ID を取得
+        completed_ids = if current_user
+          current_user.user_progresses
+            .where(lesson_id: lessons.map(&:id), quiz_id: nil, status: "completed")
+            .pluck(:lesson_id)
+            .to_set
+        else
+          Set.new
         end
-        render json: { course: course_json(course).merge(lessons:) }
+
+        lesson_list = lessons.each_with_index.map do |l, i|
+          # 1つ目は常に開放、2つ目以降は前レッスン完了で開放
+          locked = i > 0 && !completed_ids.include?(lessons[i - 1].id)
+          { id: l.id, title: l.title, position: l.position, locked: }
+        end
+
+        render json: { course: course_json(course).merge(lessons: lesson_list) }
       end
 
       private
+
+      def current_user
+        return @current_user if defined?(@current_user)
+        token = request.headers["Authorization"]&.split(" ")&.last
+        return @current_user = nil unless token
+        payload = ::JwtService.decode(token)
+        @current_user = ::User.find_by(id: payload[:user_id])
+      rescue ApplicationController::AuthenticationError
+        @current_user = nil
+      end
 
       def course_json(course)
         {

--- a/backend/app/controllers/api/v1/user/progress_controller.rb
+++ b/backend/app/controllers/api/v1/user/progress_controller.rb
@@ -27,6 +27,13 @@ module Api
             completed = completed_lessons + completed_quizzes
             progress_pct = total > 0 ? (completed * 100 / total) : 0
 
+            # 次に学習するレッスン（最初の未完了レッスン）
+            next_lesson = lessons.find do |l|
+              !current_user.user_progresses
+                .exists?(lesson: l, quiz_id: nil, status: "completed")
+            end
+            next_lesson_info = next_lesson ? { id: next_lesson.id, title: next_lesson.title } : nil
+
             {
               course_id: course.id,
               title: course.title,
@@ -36,7 +43,8 @@ module Api
               total_quizzes:,
               completed_lessons:,
               completed_quizzes:,
-              progress_pct:
+              progress_pct:,
+              next_lesson: next_lesson_info
             }
           end
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@types/react-syntax-highlighter": "^15.5.13",
         "axios": "^1.13.6",
         "lucide-react": "^0.577.0",
@@ -1035,6 +1036,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1643,6 +1667,14 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3025,6 +3057,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -5350,6 +5392,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6020,6 +6075,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -7113,6 +7179,12 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "axios": "^1.13.6",
     "lucide-react": "^0.577.0",

--- a/frontend/src/app/courses/[courseId]/LessonList.tsx
+++ b/frontend/src/app/courses/[courseId]/LessonList.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { apiClient } from "@/lib/api";
+import type { Lesson } from "@/lib/types";
+
+type LessonSummary = Pick<Lesson, "id" | "title" | "position"> & {
+  locked: boolean;
+};
+
+type Props = {
+  courseId: string;
+  initialLessons: LessonSummary[];
+};
+
+export default function LessonList({ courseId, initialLessons }: Props) {
+  const [lessons, setLessons] = useState<LessonSummary[]>(initialLessons);
+
+  useEffect(() => {
+    // ログイン済みなら再フェッチしてロック状態を更新
+    const token = localStorage.getItem("token");
+    if (!token) return;
+
+    apiClient
+      .get<{ course: { lessons: LessonSummary[] } }>(`/courses/${courseId}`)
+      .then((res) => setLessons(res.data.course.lessons))
+      .catch(() => {});
+  }, [courseId]);
+
+  return (
+    <ol className="space-y-3">
+      {lessons.map((lesson, index) => (
+        <li key={lesson.id}>
+          {lesson.locked ? (
+            <div className="flex cursor-not-allowed items-center gap-4 rounded-lg border bg-gray-50 px-5 py-4 text-gray-400">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-sm font-bold">
+                {index + 1}
+              </span>
+              <span className="font-medium">{lesson.title}</span>
+              <span className="ml-auto text-xs">🔒 前のレッスンを完了してください</span>
+            </div>
+          ) : (
+            <Link
+              href={`/courses/${courseId}/lessons/${lesson.id}`}
+              className="flex items-center gap-4 rounded-lg border bg-white px-5 py-4 shadow-sm transition hover:border-indigo-400 hover:shadow-md"
+            >
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-sm font-bold text-indigo-700">
+                {index + 1}
+              </span>
+              <span className="font-medium text-gray-800">{lesson.title}</span>
+            </Link>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/app/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/frontend/src/app/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -6,6 +6,7 @@ import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import type { Components } from "react-markdown";
 import type { Lesson, Quiz } from "@/lib/types";
 import QuizCard from "@/components/quiz/QuizCard";
+import CodeChallengeCard from "@/components/quiz/CodeChallengeCard";
 import LessonCompleteButton from "./LessonCompleteButton";
 
 type LessonDetail = Lesson & {
@@ -83,9 +84,13 @@ export default async function LessonPage({
             確認クイズ
           </h2>
           <div className="space-y-6">
-            {lesson.quizzes.map((quiz) => (
-              <QuizCard key={quiz.id} quiz={quiz} />
-            ))}
+            {lesson.quizzes.map((quiz) =>
+              quiz.quiz_type === "code_challenge" ? (
+                <CodeChallengeCard key={quiz.id} quiz={quiz} />
+              ) : (
+                <QuizCard key={quiz.id} quiz={quiz} />
+              )
+            )}
           </div>
         </section>
       )}

--- a/frontend/src/app/courses/[courseId]/page.tsx
+++ b/frontend/src/app/courses/[courseId]/page.tsx
@@ -1,10 +1,12 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Course, Lesson } from "@/lib/types";
+import LessonList from "./LessonList";
 
-type CourseDetail = Course & {
-  lessons: Pick<Lesson, "id" | "title" | "position">[];
+type LessonSummary = Pick<Lesson, "id" | "title" | "position"> & {
+  locked: boolean;
 };
+type CourseDetail = Course & { lessons: LessonSummary[] };
 
 async function getCourse(id: string): Promise<CourseDetail> {
   const baseURL =
@@ -38,21 +40,9 @@ export default async function CourseDetailPage({
       <p className="mb-8 text-gray-600">{course.description}</p>
 
       <h2 className="mb-4 text-xl font-semibold text-gray-800">レッスン一覧</h2>
-      <ol className="space-y-3">
-        {course.lessons.map((lesson, index) => (
-          <li key={lesson.id}>
-            <Link
-              href={`/courses/${courseId}/lessons/${lesson.id}`}
-              className="flex items-center gap-4 rounded-lg border bg-white px-5 py-4 shadow-sm transition hover:border-indigo-400 hover:shadow-md"
-            >
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-sm font-bold text-indigo-700">
-                {index + 1}
-              </span>
-              <span className="font-medium text-gray-800">{lesson.title}</span>
-            </Link>
-          </li>
-        ))}
-      </ol>
+      {/* initialLessons: SSR 時は未認証なので 1 つ目以外はロック済み */}
+      {/* クライアントで再フェッチしてログイン済みユーザーのロック状態を反映 */}
+      <LessonList courseId={courseId} initialLessons={course.lessons} />
     </div>
   );
 }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -16,6 +16,7 @@ type CourseProgress = {
   completed_lessons: number;
   completed_quizzes: number;
   progress_pct: number;
+  next_lesson: { id: number; title: string } | null;
 };
 
 const categoryLabel: Record<string, string> = {
@@ -66,10 +67,33 @@ export default function DashboardPage() {
         )
       : 0;
 
+  // 進捗が途中のコースで次のレッスンがあるものを「続きから学習」候補にする
+  const resumeTarget = progress.find(
+    (p) => p.progress_pct > 0 && p.progress_pct < 100 && p.next_lesson
+  ) ?? progress.find((p) => p.next_lesson);
+
   return (
     <div className="mx-auto max-w-4xl px-6 py-12">
       <h1 className="mb-2 text-3xl font-bold text-gray-900">ダッシュボード</h1>
       <p className="mb-8 text-gray-600">こんにちは、{user?.name} さん</p>
+
+      {/* 続きから学習 */}
+      {resumeTarget?.next_lesson && (
+        <div className="mb-8 rounded-xl border border-indigo-200 bg-indigo-50 p-5">
+          <p className="mb-1 text-sm font-medium text-indigo-600">
+            続きから学習
+          </p>
+          <p className="mb-3 text-lg font-semibold text-gray-900">
+            {resumeTarget.title} — {resumeTarget.next_lesson.title}
+          </p>
+          <Link
+            href={`/courses/${resumeTarget.course_id}/lessons/${resumeTarget.next_lesson.id}`}
+            className="inline-block rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          >
+            学習を再開する →
+          </Link>
+        </div>
+      )}
 
       {/* 全体進捗 */}
       <div className="mb-8 rounded-xl border bg-white p-6 shadow-sm">
@@ -83,6 +107,9 @@ export default function DashboardPage() {
             style={{ width: `${totalPct}%` }}
           />
         </div>
+        <p className="mt-2 text-sm text-gray-500">
+          {progress.filter((p) => p.progress_pct === 100).length} / {progress.length} コース完了
+        </p>
       </div>
 
       {/* コース別進捗 */}
@@ -101,6 +128,11 @@ export default function DashboardPage() {
                   >
                     {p.difficulty}
                   </span>
+                  {p.progress_pct === 100 && (
+                    <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+                      ✓ 完了
+                    </span>
+                  )}
                 </div>
                 <Link
                   href={`/courses/${p.course_id}`}
@@ -121,31 +153,32 @@ export default function DashboardPage() {
               />
             </div>
 
-            <div className="flex gap-6 text-sm text-gray-600">
-              <span>
-                レッスン:{" "}
-                <span className="font-medium text-gray-900">
-                  {p.completed_lessons}/{p.total_lessons}
+            <div className="flex items-center justify-between">
+              <div className="flex gap-6 text-sm text-gray-600">
+                <span>
+                  レッスン:{" "}
+                  <span className="font-medium text-gray-900">
+                    {p.completed_lessons}/{p.total_lessons}
+                  </span>
                 </span>
-              </span>
-              <span>
-                クイズ:{" "}
-                <span className="font-medium text-gray-900">
-                  {p.completed_quizzes}/{p.total_quizzes}
+                <span>
+                  クイズ:{" "}
+                  <span className="font-medium text-gray-900">
+                    {p.completed_quizzes}/{p.total_quizzes}
+                  </span>
                 </span>
-              </span>
+              </div>
+              {p.next_lesson && p.progress_pct < 100 && (
+                <Link
+                  href={`/courses/${p.course_id}/lessons/${p.next_lesson.id}`}
+                  className="rounded-md bg-indigo-50 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:bg-indigo-100"
+                >
+                  続きへ →
+                </Link>
+              )}
             </div>
           </div>
         ))}
-      </div>
-
-      <div className="mt-8 text-center">
-        <Link
-          href="/courses"
-          className="inline-block rounded-lg bg-indigo-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-indigo-700"
-        >
-          学習を続ける
-        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/quiz/CodeChallengeCard.tsx
+++ b/frontend/src/components/quiz/CodeChallengeCard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import type { Quiz } from "@/lib/types";
+import { apiClient } from "@/lib/api";
+
+// Monaco Editor は SSR 非対応のため dynamic import
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-48 items-center justify-center rounded-md bg-gray-900 text-sm text-gray-400">
+      エディタを読み込み中...
+    </div>
+  ),
+});
+
+type Props = {
+  quiz: Quiz;
+};
+
+export default function CodeChallengeCard({ quiz }: Props) {
+  const [code, setCode] = useState(quiz.starter_code ?? "");
+  const [result, setResult] = useState<{
+    correct: boolean;
+    explanation: string | null;
+  } | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [showHints, setShowHints] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const res = await apiClient.post<{
+        correct: boolean;
+        explanation: string | null;
+      }>(`/quizzes/${quiz.id}/answer`, { answer: code });
+      setResult(res.data);
+    } catch {
+      setResult({ correct: false, explanation: "送信に失敗しました" });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border bg-white shadow-sm">
+      {/* ヘッダー */}
+      <div className="border-b bg-gray-50 px-5 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+        Code Challenge
+      </div>
+
+      <div className="p-5">
+        {/* 問題文 */}
+        <p className="mb-4 font-semibold text-gray-900">{quiz.question}</p>
+
+        {/* ヒント */}
+        {quiz.hints && quiz.hints.length > 0 && (
+          <div className="mb-4">
+            <button
+              onClick={() => setShowHints(!showHints)}
+              className="text-sm text-indigo-600 hover:underline"
+            >
+              {showHints ? "ヒントを隠す" : `ヒントを見る (${quiz.hints.length}件)`}
+            </button>
+            {showHints && (
+              <ul className="mt-2 space-y-1">
+                {quiz.hints.map((hint, i) => (
+                  <li
+                    key={i}
+                    className="rounded-md bg-yellow-50 px-3 py-2 text-sm text-yellow-800"
+                  >
+                    💡 {hint}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {/* Monaco Editor */}
+        <div className="mb-4 overflow-hidden rounded-lg border">
+          <MonacoEditor
+            height="200px"
+            language="typescript"
+            theme="vs-dark"
+            value={code}
+            onChange={(val) => setCode(val ?? "")}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 14,
+              lineNumbers: "on",
+              scrollBeyondLastLine: false,
+              readOnly: !!result,
+              tabSize: 2,
+            }}
+          />
+        </div>
+
+        {!result && (
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !code.trim()}
+            className="rounded-md bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {submitting ? "送信中..." : "コードを送信"}
+          </button>
+        )}
+
+        {result && (
+          <div
+            className={`rounded-lg p-4 ${
+              result.correct ? "bg-green-50 text-green-800" : "bg-red-50 text-red-800"
+            }`}
+          >
+            <p className="font-semibold">{result.correct ? "正解！" : "不正解"}</p>
+            {result.explanation && (
+              <p className="mt-1 text-sm">{result.explanation}</p>
+            )}
+            {!result.correct && (
+              <button
+                onClick={() => setResult(null)}
+                className="mt-2 text-sm underline"
+              >
+                もう一度試す
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **#16 レッスンロック**: 前のレッスン未完了時は 🔒 でリンク無効化。Client Component で CSR 再フェッチしてロック状態をリアルタイム反映。
- **#17 ダッシュボード改善**: 「続きから学習」バナー、コース別「続きへ →」ボタン、完了バッジ、コース完了数表示。
- **#18 Monaco Editor + コードチャレンジ**: `quiz_type === 'code_challenge'` 時に Monaco Editor 表示、ヒントトグル、再挑戦ボタン。

Closes #16
Closes #17
Closes #18

## Test plan

- [ ] コース詳細でレッスン 2 以降が 🔒 表示
- [ ] レッスン 1 完了後、コース詳細でレッスン 2 のロックが解除される
- [ ] ダッシュボードに「続きから学習」バナーが表示される
- [ ] コードチャレンジ型クイズで Monaco Editor が表示される
- [ ] ヒントトグルが動作する
- [ ] 不正解時に「もう一度試す」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)