### PR TITLE
chore: Render + Neon デプロイ設定

### DIFF
--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -1,104 +1,19 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/opt/homebrew/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  connect_timeout: 10
 
 development:
   <<: *default
-  database: app_development
+  url: <%= ENV.fetch("DATABASE_URL", "postgresql://postgres:postgres@db:5432/app_development") %>
 
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: app
-
-  # The password associated with the PostgreSQL role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: app_test
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Connection URLs for non-primary databases can also be configured using
-# environment variables. The variable name is formed by concatenating the
-# connection name with `_DATABASE_URL`. For example:
-#
-#   CACHE_DATABASE_URL="postgres://cacheuser:cachepass@localhost/cachedatabase"
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
+# 本番: DATABASE_URL 環境変数で全て指定（Neon 等の外部 DB）
+# 例: postgresql://user:pass@host.neon.tech/dbname?sslmode=require
 production:
-  primary: &primary_production
-    <<: *default
-    database: app_production
-    username: app
-    password: <%= ENV["APP_DATABASE_PASSWORD"] %>
-  cache:
-    <<: *primary_production
-    database: app_production_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    database: app_production_queue
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_production
-    database: app_production_cable
-    migrations_paths: db/cable_migrate
+  <<: *default
+  url: <%= ENV["DATABASE_URL"] %>

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -1,87 +1,26 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # Code is not reloaded between requests.
   config.enable_reloading = false
-
-  # Eager load code on boot for better performance and memory savings (ignored by Rake tasks).
   config.eager_load = true
-
-  # Full error reports are disabled.
   config.consider_all_requests_local = false
 
-  # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  # Render は SSL termination を行うリバースプロキシを提供する
+  config.assume_ssl = true
+  config.force_ssl  = true
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
-
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
-
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
-
-  # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
-
-  # Change to "debug" to log everything (including potentially personally-identifiable information!).
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"
-
-  # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :solid_cache_store
-
-  # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
-
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
-
-  # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # Render のドメインを許可（HostAuthorization）
+  config.hosts << /.*\.onrender\.com/
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Render デプロイ用: standalone モードで依存ファイルを最小化
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,38 @@
+# Render Blueprint — https://render.com/docs/blueprint-spec
+# デプロイ前に以下の環境変数をダッシュボードで手動設定:
+#   backend: DATABASE_URL, FRONTEND_ORIGIN
+#   frontend: NEXT_PUBLIC_API_URL, INTERNAL_API_URL
+
+services:
+  # ── Backend (Rails API) ─────────────────────────────────
+  - type: web
+    name: next-practice-backend
+    runtime: ruby
+    rootDir: backend
+    buildCommand: bundle install
+    startCommand: bundle exec rails db:migrate && bundle exec rails s -p $PORT -b 0.0.0.0
+    healthCheckPath: /up
+    envVars:
+      - key: RAILS_ENV
+        value: production
+      - key: RAILS_LOG_LEVEL
+        value: info
+      - key: SECRET_KEY_BASE
+        generateValue: true
+      - key: JWT_SECRET
+        generateValue: true
+      # 手動設定が必要な変数（Render ダッシュボードで設定）
+      # DATABASE_URL: postgresql://user:pass@host.neon.tech/dbname?sslmode=require
+      # FRONTEND_ORIGIN: https://next-practice-frontend.onrender.com
+
+  # ── Frontend (Next.js) ──────────────────────────────────
+  - type: web
+    name: next-practice-frontend
+    runtime: node
+    rootDir: frontend
+    buildCommand: npm ci && npm run build
+    startCommand: node .next/standalone/server.js
+    envVars:
+      # 手動設定が必要な変数（Render ダッシュボードで設定）
+      # NEXT_PUBLIC_API_URL: https://next-practice-backend.onrender.com/api/v1
+      # INTERNAL_API_URL:    https://next-practice-backend.onrender.com/api/v1


### PR DESCRIPTION
## Summary

- `render.yaml`: Blueprint (backend Rails / frontend Next.js)
- `database.yml`: production を `DATABASE_URL` 環境変数で統一 (Neon SSL対応)
- `production.rb`: `assume_ssl` / `force_ssl` / Render ホスト認証設定
- `next.config.ts`: `output: "standalone"` でビルド最適化

## Render デプロイ手順

### 1. Neon データベース作成
1. https://neon.tech にアクセスしてプロジェクト作成
2. Connection string (DATABASE_URL) をコピー: `postgresql://...@*.neon.tech/neondb?sslmode=require`

### 2. Render にデプロイ
1. https://render.com でアカウント作成
2. New → Blueprint → GitHub リポジトリを選択 → `render.yaml` を自動検出
3. `next-practice-backend` の環境変数を設定:
   - `DATABASE_URL` = Neon の接続文字列
   - `FRONTEND_ORIGIN` = `https://next-practice-frontend.onrender.com`
4. `next-practice-frontend` の環境変数を設定:
   - `NEXT_PUBLIC_API_URL` = `https://next-practice-backend.onrender.com/api/v1`
   - `INTERNAL_API_URL` = `https://next-practice-backend.onrender.com/api/v1`
5. 「Apply」でデプロイ開始

### 3. 初回セットアップ
```bash
# Neon DB にシードデータを投入（backend の Shell タブで実行）
bundle exec rails db:seed
```

## Test plan

- [ ] Render デプロイ成功 (両サービスが `Live` 状態)
- [ ] `curl https://next-practice-backend.onrender.com/up` → `{"status":"ok"}`
- [ ] `curl https://next-practice-backend.onrender.com/api/v1/courses` → コース一覧
- [ ] ブラウザで `https://next-practice-frontend.onrender.com` にアクセス

🤖 Generated with [Claude Code](https://claude.com/claude-code)