### PR TITLE
fix: Render デプロイ — Dockerfile.dev リネームでネイティブ環境を使用

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,22 @@
+FROM ruby:3.3-slim
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      libpq-dev \
+      libyaml-dev \
+      postgresql-client \
+      curl \
+      git && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs 4 --retry 3
+
+COPY . .
+
+EXPOSE 3001
+
+CMD ["bundle", "exec", "rails", "server", "-p", "3001", "-b", "0.0.0.0"]

--- a/compose.yml
+++ b/compose.yml
@@ -18,7 +18,7 @@ services:
   backend:
     build:
       context: ./backend
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails db:prepare && bundle exec rails s -p 3001 -b '0.0.0.0'"
     volumes:
       - ./backend:/app
@@ -38,7 +38,7 @@ services:
   frontend:
     build:
       context: ./frontend
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     command: npm run dev
     volumes:
       - ./frontend:/app

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000

--- a/render.yaml
+++ b/render.yaml
@@ -21,9 +21,7 @@ services:
         generateValue: true
       - key: JWT_SECRET
         generateValue: true
-      # 手動設定が必要な変数（Render ダッシュボードで設定）
-      # DATABASE_URL: postgresql://user:pass@host.neon.tech/dbname?sslmode=require
-      # FRONTEND_ORIGIN: https://next-practice-frontend.onrender.com
+      # 手動設定: DATABASE_URL, FRONTEND_ORIGIN
 
   # ── Frontend (Next.js) ──────────────────────────────────
   - type: web
@@ -33,6 +31,6 @@ services:
     buildCommand: npm ci && npm run build
     startCommand: node .next/standalone/server.js
     envVars:
-      # 手動設定が必要な変数（Render ダッシュボードで設定）
-      # NEXT_PUBLIC_API_URL: https://next-practice-backend.onrender.com/api/v1
-      # INTERNAL_API_URL:    https://next-practice-backend.onrender.com/api/v1
+      - key: PORT
+        value: "3000"
+      # 手動設定: NEXT_PUBLIC_API_URL, INTERNAL_API_URL


### PR DESCRIPTION
## 問題
Render が `rootDir` に `Dockerfile` を見つけると Docker ビルドモードになり、
`render.yaml` の `runtime: ruby` が無視される。

## 修正
- `backend/Dockerfile` → `backend/Dockerfile.dev`
- `frontend/Dockerfile` → `frontend/Dockerfile.dev`
- `compose.yml` の `dockerfile:` を `Dockerfile.dev` に更新

Render は `Dockerfile` が存在しないため `runtime: ruby` / `runtime: node` のネイティブ環境でビルドされる。ローカルの Docker Compose は `Dockerfile.dev` を参照するため引き続き動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)